### PR TITLE
Added Generic Separate Boxes for Entering OTP 

### DIFF
--- a/src/components/otpBox/index.js
+++ b/src/components/otpBox/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 export const OTPBox = (props) => {
     const {
         OTPInputIds,
@@ -9,24 +10,22 @@ export const OTPBox = (props) => {
     const lengthOfOTP = OTPInputIds.length;
 
     const handleOTPinput = (event) => {
-        const { value, dataset: { otpid, index } } = event.target;
-        if (otp[otpid] === '') {
-            setOtp({ ...otp, [otpid]: isOneDigitNumber(value) ? value : otp[otpid] });
+        const {value, dataset: {otpid, index}} = event.target;
+        if (otp[otpid] === '' && isOneDigitNumber(value)) {
+            setOtp({...otp, [otpid]: value});
             focusToNextBox(index, value);
-        }
-        else if (value === "") {
-            setOtp({ ...otp, [otpid]: value });
-        }
-        else {
+        } else if (value === '') {
+            setOtp({...otp, [otpid]: value});
+        } else {
             const newValue = value.slice(otp[otpid].length) || value;
-            setOtp({ ...otp, [otpid]: isOneDigitNumber(newValue) ? newValue : otp[otpid] });
+            isOneDigitNumber(newValue) && setOtp({...otp, [otpid]: newValue});
             focusToNextBox(index, value);
         }
     };
 
     const checkBackSpace = (event) => {
-        const { dataset: { otpid, index, } } = event.target;
-        if ((event.key == 'Backspace' || event.keyCode === 8) && !otp[otpid]) {
+        const {dataset: {otpid, index}} = event.target;
+        if ((event.key === 'Backspace' || event.keyCode === 8) && !otp[otpid]) {
             event.preventDefault();
             focusToPreviousBox(index);
         }
@@ -35,28 +34,30 @@ export const OTPBox = (props) => {
     const isOneDigitNumber = (value) => !isNaN(value) && value.length === 1;
 
     const focusToNextBox = (index, value) => {
-        parseInt(index) < lengthOfOTP - 1 && isOneDigitNumber(value) && inputsRef[parseInt(index) + 1].focus();
+        if ((parseInt(index, 10) < lengthOfOTP - 1) && isOneDigitNumber(value)) {
+            inputsRef[parseInt(index, 10) + 1].focus();
+        }
     };
 
     const focusToPreviousBox = (index) => {
-        parseInt(index) > 0 && inputsRef[parseInt(index) - 1].focus();
+        if (parseInt(index, 10) > 0) {
+            inputsRef[parseInt(index, 10) - 1].focus();
+        }
     };
-
-
 
     return (
         OTPInputIds.map((each, index) => (
             <input
-                autoFocus={index == 0}
+                autoFocus={index === 0}
                 value={otp[each]}
                 data-otpid={each}
                 data-index={index}
                 onChange={handleOTPinput}
-                ref={el => inputsRef[index] = el}
+                ref={(el) => inputsRef[index] = el}
                 key={each + index}
                 onKeyDown={checkBackSpace}
             />
         ))
 
-    )
-}
+    );
+};

--- a/src/components/otpBox/index.js
+++ b/src/components/otpBox/index.js
@@ -35,11 +35,11 @@ export const OTPBox = (props) => {
     const isOneDigitNumber = (value) => !isNaN(value) && value.length === 1;
 
     const focusToNextBox = (index, value) => {
-        parseInt(index) < lengthOfOTP - 1 && isOneDigitNumber(value) && inputsRef.current[parseInt(index) + 1].focus();
+        parseInt(index) < lengthOfOTP - 1 && isOneDigitNumber(value) && inputsRef[parseInt(index) + 1].focus();
     };
 
     const focusToPreviousBox = (index) => {
-        parseInt(index) > 0 && inputsRef.current[parseInt(index) - 1].focus();
+        parseInt(index) > 0 && inputsRef[parseInt(index) - 1].focus();
     };
 
 
@@ -52,7 +52,7 @@ export const OTPBox = (props) => {
                 data-otpid={each}
                 data-index={index}
                 onChange={handleOTPinput}
-                ref={el => inputsRef.current[index] = el}
+                ref={el => inputsRef[index] = el}
                 key={each + index}
                 onKeyDown={checkBackSpace}
             />

--- a/src/components/otpBox/index.js
+++ b/src/components/otpBox/index.js
@@ -1,0 +1,62 @@
+import React from 'react';
+export const OTPBox = (props) => {
+    const {
+        OTPInputIds,
+        otp,
+        setOtp,
+        inputsRef
+    } = props;
+    const lengthOfOTP = OTPInputIds.length;
+
+    const handleOTPinput = (event) => {
+        const { value, dataset: { otpid, index } } = event.target;
+        if (otp[otpid] === '') {
+            setOtp({ ...otp, [otpid]: isOneDigitNumber(value) ? value : otp[otpid] });
+            focusToNextBox(index, value);
+        }
+        else if (value === "") {
+            setOtp({ ...otp, [otpid]: value });
+        }
+        else {
+            const newValue = value.slice(otp[otpid].length) || value;
+            setOtp({ ...otp, [otpid]: isOneDigitNumber(newValue) ? newValue : otp[otpid] });
+            focusToNextBox(index, value);
+        }
+    };
+
+    const checkBackSpace = (event) => {
+        const { dataset: { otpid, index, } } = event.target;
+        if ((event.key == 'Backspace' || event.keyCode === 8) && !otp[otpid]) {
+            event.preventDefault();
+            focusToPreviousBox(index);
+        }
+    };
+
+    const isOneDigitNumber = (value) => !isNaN(value) && value.length === 1;
+
+    const focusToNextBox = (index, value) => {
+        parseInt(index) < lengthOfOTP - 1 && isOneDigitNumber(value) && inputsRef.current[parseInt(index) + 1].focus();
+    };
+
+    const focusToPreviousBox = (index) => {
+        parseInt(index) > 0 && inputsRef.current[parseInt(index) - 1].focus();
+    };
+
+
+
+    return (
+        OTPInputIds.map((each, index) => (
+            <input
+                autoFocus={index == 0}
+                value={otp[each]}
+                data-otpid={each}
+                data-index={index}
+                onChange={handleOTPinput}
+                ref={el => inputsRef.current[index] = el}
+                key={each + index}
+                onKeyDown={checkBackSpace}
+            />
+        ))
+
+    )
+}

--- a/src/pages/welcome/VerifyOTP.js
+++ b/src/pages/welcome/VerifyOTP.js
@@ -40,7 +40,7 @@ const VerifyOTP = (props) => {
         setEnterOTPVisible
     } = withAuthProps;
 
-    const inputsRef = useRef(OTPInputIds.map(() => createRef()));
+    const inputsRef = OTPInputIds.map(() => useRef(null));
 
     useEffect(() => {
         setEnterOTPVisible(false);

--- a/src/pages/welcome/VerifyOTP.js
+++ b/src/pages/welcome/VerifyOTP.js
@@ -1,15 +1,15 @@
-import React, { useState, useEffect, useRef, createRef } from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
-import { NavBar } from '../../components/navBar';
-import { Footer } from '../../components/footer';
-import { Loader } from '../../components/loader';
-import { WELCOME } from '../../constants';
-import { Background } from '../../components/background';
-import { useToast } from '../../components/toast';
+import {useHistory} from 'react-router-dom';
+import {NavBar} from '../../components/navBar';
+import {Footer} from '../../components/footer';
+import {Loader} from '../../components/loader';
+import {WELCOME} from '../../constants';
+import {Background} from '../../components/background';
+import {useToast} from '../../components/toast';
 
-import { resendOtpAPI } from '../../api/resendOTP';
-import { OTPBox } from '../../components/otpBox';
+import {resendOtpAPI} from '../../api/resendOTP';
+import {OTPBox} from '../../components/otpBox';
 
 const OTPValuesInitial = {
     input1: '',
@@ -28,7 +28,7 @@ const VerifyOTP = (props) => {
     const history = useHistory();
     const addToast = useToast();
 
-    const { withAuthProps } = props;
+    const {withAuthProps} = props;
 
     const {
         sendOTP,
@@ -50,10 +50,9 @@ const VerifyOTP = (props) => {
         if (user?.email) setEmail(user.email);
     }, [user]);
 
+    const OTPEntered = Object.values(otp).join('');
 
-    const OTPEntered = Object.values(otp).reduce((acc, currentVal) => String(acc) + String(currentVal), '');
-
-    const isOTPValid = () => !isNaN(OTPEntered) && OTPEntered.length === 6;
+    const isOTPValid = !isNaN(OTPEntered) && OTPEntered.length === 6;
 
     const handleVerifyOTP = () => {
         verifyOTP({
@@ -132,7 +131,7 @@ const VerifyOTP = (props) => {
                                             Resend
                                         </span>
                                     </div>
-                                    <button className="standard-button" disabled={!isOTPValid()} onClick={handleVerifyOTP}>
+                                    <button className="standard-button" disabled={!isOTPValid} onClick={handleVerifyOTP}>
                                         {loading ? <Loader /> : 'Verify'}
                                     </button>
                                 </footer>
@@ -140,32 +139,33 @@ const VerifyOTP = (props) => {
                         </article>
                     </section>
                 ) : (
-                        <section className="login-content">
-                            <article className="login-article article">
-                                <div className="login-modal animate-1">
-                                    <div className="login-header">Verify your Email Address</div>
-                                    <div className="login-subheader">{`Please confirm to request an OTP to your registered email address.`}</div>
-                                    <div className="login-form">
-                                        <div className="form-row">
-                                            <div className="form-label">EMAIL</div>
-                                            <input
-                                                value={email}
-                                                readOnly={Boolean(user)}
-                                                onChange={updateEmail}
-                                            />
-                                        </div>
-                                        <div className="form-error-row" />
+                    <section className="login-content">
+                        <article className="login-article article">
+                            <div className="login-modal animate-1">
+                                <div className="login-header">Verify your Email Address</div>
+                                <div className="login-subheader">{`Please confirm to request an OTP to your registered email address.`}</div>
+                                <div className="login-form">
+                                    <div className="form-row">
+                                        <div className="form-label">EMAIL</div>
+                                        <input
+                                            value={email}
+                                            readOnly={Boolean(user)}
+                                            onChange={updateEmail}
+                                            autoFocus
+                                        />
                                     </div>
-                                    <footer className="login-footer">
-                                        <div className="login-footer-link-wrapper" />
-                                        <button className="standard-button" onClick={requestOTP}>
-                                            {loading ? <Loader /> : 'Confirm'}
-                                        </button>
-                                    </footer>
+                                    <div className="form-error-row" />
                                 </div>
-                            </article>
-                        </section>
-                    )}
+                                <footer className="login-footer">
+                                    <div className="login-footer-link-wrapper" />
+                                    <button className="standard-button" onClick={requestOTP}>
+                                        {loading ? <Loader /> : 'Confirm'}
+                                    </button>
+                                </footer>
+                            </div>
+                        </article>
+                    </section>
+                )}
                 <Footer />
             </main>
         </div>

--- a/src/pages/welcome/VerifyOTP.js
+++ b/src/pages/welcome/VerifyOTP.js
@@ -1,23 +1,30 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect, useRef, createRef } from 'react';
 import PropTypes from 'prop-types';
-import {useHistory} from 'react-router-dom';
-import {NavBar} from '../../components/navBar';
-import {Footer} from '../../components/footer';
-import {Loader} from '../../components/loader';
-import {WELCOME} from '../../constants';
-import {Background} from '../../components/background';
-import {useToast} from '../../components/toast';
+import { useHistory } from 'react-router-dom';
+import { NavBar } from '../../components/navBar';
+import { Footer } from '../../components/footer';
+import { Loader } from '../../components/loader';
+import { WELCOME } from '../../constants';
+import { Background } from '../../components/background';
+import { useToast } from '../../components/toast';
 
-import {resendOtpAPI} from '../../api/resendOTP';
-
+import { resendOtpAPI } from '../../api/resendOTP';
+const OTPinputs = [{ id: 'input1' }, { id: 'input2' }, { id: 'input3' }, { id: 'input4' }, { id: 'input5' }, { id: 'input6' }]
 const VerifyOTP = (props) => {
     const [email, setEmail] = useState('');
-    const [otp, setOtp] = useState('');
+    const [otp, setOtp] = useState({
+        input1: '',
+        input2: '',
+        input3: '',
+        input4: '',
+        input5: '',
+        input6: ''
+    });
 
     const history = useHistory();
     const addToast = useToast();
 
-    const {withAuthProps} = props;
+    const { withAuthProps } = props;
 
     const {
         sendOTP,
@@ -29,6 +36,7 @@ const VerifyOTP = (props) => {
         setEnterOTPVisible
     } = withAuthProps;
 
+    const inputsRef = useRef(OTPinputs.map(() => createRef()));
     useEffect(() => {
         setEnterOTPVisible(false);
     }, []);
@@ -36,7 +44,29 @@ const VerifyOTP = (props) => {
     useEffect(() => {
         if (user?.email) setEmail(user.email);
     }, [user]);
-
+    const isOneDigitNumber = (value) => !isNaN(value) && value.length === 1;
+    const handleOTPinput = (event) => {
+        const { value, dataset: { otpid, index } } = event.target;
+        if (otp[otpid] === '') {
+            setOtp({ ...otp, [otpid]: isOneDigitNumber(value) ? value : otp[otpid] });
+            isOneDigitNumber(value) && inputsRef.current[parseInt(index) + 1].focus();
+        }
+        else if (value === "") {
+            setOtp({ ...otp, [otpid]: value });
+        }
+        else {
+            const newValue = value.slice(otp[otpid].length) || value;
+            setOtp({ ...otp, [otpid]: isOneDigitNumber(newValue) ? newValue : otp[otpid] });
+            isOneDigitNumber(newValue) && inputsRef.current[parseInt(index) + 1].focus();
+        }
+    }
+    const checkBackSpace = (event) => {
+        const { value, dataset: { otpid, index,  } } = event.target;
+        if (event.key == 'Backspace', event.keyCode === 8 && !otp[otpid] ) {
+            event.preventDefault();
+            parseInt(index) > 0 && inputsRef.current[parseInt(index) - 1].focus();
+        }
+    }
     const handleVerifyOTP = () => {
         verifyOTP({
             id: user.id,
@@ -87,20 +117,28 @@ const VerifyOTP = (props) => {
                         <i className="fas fa-arrow-left" />
                     </button>
                 </NavBar>
-                {enterOTPVisible ? (
+                {1 ? (
                     <section className="login-content">
                         <article className="login-article article">
                             <div className="login-modal animate-1">
                                 <div className="login-header">Verify OTP</div>
                                 <div className="login-subheader">Please enter the 6-digit OTP sent to <span className="login-email">{email}</span>.</div>
                                 <div className="login-form">
-                                    <div className="form-row">
-                                        <div className="form-label">OTP</div>
-                                        <input
-                                            autoFocus
-                                            value={otp}
-                                            onChange={(e) => setOtp(e.target.value)}
-                                        />
+                                    <div className="form-row otp-inputs">
+                                        {
+                                            OTPinputs.map((each, index) => (
+                                                <input
+                                                    autoFocus={index == 0}
+                                                    value={otp[each.id]}
+                                                    data-otpid={each.id}
+                                                    data-index={index}
+                                                    onChange={handleOTPinput}
+                                                    ref={el => inputsRef.current[index] = el}
+                                                    key={each.id}
+                                                    onKeyDown={checkBackSpace}
+                                                />
+                                            ))
+                                        }
                                     </div>
                                     <div className="form-error-row" />
                                 </div>
@@ -122,32 +160,32 @@ const VerifyOTP = (props) => {
                         </article>
                     </section>
                 ) : (
-                    <section className="login-content">
-                        <article className="login-article article">
-                            <div className="login-modal animate-1">
-                                <div className="login-header">Verify your Email Address</div>
-                                <div className="login-subheader">{`Please confirm to request an OTP to your registered email address.`}</div>
-                                <div className="login-form">
-                                    <div className="form-row">
-                                        <div className="form-label">EMAIL</div>
-                                        <input
-                                            value={email}
-                                            readOnly={Boolean(user)}
-                                            onChange={updateEmail}
-                                        />
+                        <section className="login-content">
+                            <article className="login-article article">
+                                <div className="login-modal animate-1">
+                                    <div className="login-header">Verify your Email Address</div>
+                                    <div className="login-subheader">{`Please confirm to request an OTP to your registered email address.`}</div>
+                                    <div className="login-form">
+                                        <div className="form-row">
+                                            <div className="form-label">EMAIL</div>
+                                            <input
+                                                value={email}
+                                                readOnly={Boolean(user)}
+                                                onChange={updateEmail}
+                                            />
+                                        </div>
+                                        <div className="form-error-row" />
                                     </div>
-                                    <div className="form-error-row" />
+                                    <footer className="login-footer">
+                                        <div className="login-footer-link-wrapper" />
+                                        <button className="standard-button" onClick={requestOTP}>
+                                            {loading ? <Loader /> : 'Confirm'}
+                                        </button>
+                                    </footer>
                                 </div>
-                                <footer className="login-footer">
-                                    <div className="login-footer-link-wrapper" />
-                                    <button className="standard-button" onClick={requestOTP}>
-                                        {loading ? <Loader /> : 'Confirm'}
-                                    </button>
-                                </footer>
-                            </div>
-                        </article>
-                    </section>
-                )}
+                            </article>
+                        </section>
+                    )}
                 <Footer />
             </main>
         </div>

--- a/src/styles/pages/welcome.scss
+++ b/src/styles/pages/welcome.scss
@@ -67,6 +67,25 @@
       }
       .login-form {
         margin-top: 50px;
+        .otp-inputs {
+          height: 70px;
+          display: flex;
+          justify-content: space-evenly;
+          align-items: center;
+          input {
+            text-align: center;
+            width: 70px;
+            height: 70px;
+            margin: 0 5px;
+            padding: 0;
+            border: 1px solid $gray;
+            border-radius: 10px;
+            background-color: lighten($color: $low-faded-black, $amount: 4);
+            &:focus {
+              border: 1px solid $green;
+            }
+          }
+        }
         .form-label {
           @include form-label();
           margin-top: 45px;
@@ -119,6 +138,39 @@
           }
           .login-footer-link {
             @include block-link();
+          }
+        }
+      }
+    }
+  }
+}
+@media only screen and (max-width: 570px) {
+  .login-content {
+    .login-article {
+      .login-modal {
+        .login-form .otp-inputs {
+          height: 60px;
+          // background-color: red;
+          input {
+            width: 50px;
+            height: 50px;
+          }
+        }
+      }
+    }
+  }
+}
+@media only screen and (max-width: 430px) {
+  .login-content {
+    .login-article {
+      .login-modal {
+        .login-form .otp-inputs {
+          height: 50px;
+          // background-color: red;
+          input {
+            width: 40px;
+            height: 40px;
+            margin: 2px;
           }
         }
       }


### PR DESCRIPTION
## This PR contains the following changes -

- Added OTPBox component which is reusable and the length of OTP can be modified anytime without any changes required in the OTPBox component.

- Built the popular OTP boxes containing separate input boxes for each digit.

Features: 
 - Each box accepts only one digit numbers
 - On entering a number, the focus is shifted to the next box
 - On backspace keypress, the focus is moved to the previous box (if exists)
 - Styled the boxes with a little creative freedom, but adhering to the theme

### Refer screenshot

<img width="924" alt="Screenshot 2020-06-09 at 4 25 16 AM" src="https://user-images.githubusercontent.com/45850634/84088054-3a6ef800-aa09-11ea-8433-54fb866760a9.png">


<em>Comments and suggestions are welcome</em>.
Cheers! 🍺


