### PR TITLE
Note Editor enhancements

### DIFF
--- a/src/pages/notes/components/NoteEditor.js
+++ b/src/pages/notes/components/NoteEditor.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {EditorState, RichUtils} from 'draft-js';
 import Editor from 'draft-js-plugins-editor';
 
-import {Modal} from '../../../components/modal';
 import {useToast} from '../../../components/toast';
 
 import {Options} from '../components/Options';
@@ -21,6 +20,8 @@ export const NoteEditor = (props) => {
     const [show, setShow] = useState(false);
     const [link, setLink] = useState('');
     const [fullScreenFlag, setFullScreenFlag] = useState(false);
+    const [optionsVisible, setOptionsVisible] = useState(false);
+
     const {addToast} = useToast();
 
     const {editorState, onChange, readOnly, editorRef} = props;
@@ -34,6 +35,12 @@ export const NoteEditor = (props) => {
             onChange(EditorState.createEmpty());
         }
     }, []);
+
+    useEffect(() => {
+        setOptionsVisible(false);
+        const timeoutId = setTimeout(() => setOptionsVisible(true), 500);
+        return (() => clearTimeout(timeoutId));
+    }, [editorState]);
 
     const enterFullScreen = () => {
         setFullScreenFlag(true);
@@ -139,6 +146,12 @@ export const NoteEditor = (props) => {
         onChange(RichUtils.toggleInlineStyle(editorState, inlineType));
     };
 
+    const outsideClick = (event) => {
+        if (event.target === event.currentTarget) {
+            hideModal();
+        }
+    };
+
     if (editorState) {
         const selection = editorState.getSelection();
         const anchorKey = selection.getAnchorKey();
@@ -184,52 +197,57 @@ export const NoteEditor = (props) => {
                         key={'editor-button-wrapper'}
                         className={`${showOptions ? 'with-options' : ''} editor-button-wrapper`}
                     >
-                        <button
-                            className="standard-button"
-                            onMouseDown={(event) => {
-                                event.preventDefault();
-                                toggleShowOptions();
-                            }}
-                        >
-                            <i className="fas fa-chevron-up" />
-                        </button>
-                        {show ?
-                            <Modal
-                                show={show}
-                                hideModal={hideModal}
+                        {optionsVisible ? (
+                            <button
+                                className={`standard-button ${optionsVisible ? '' : 'no-display'}`}
+                                onMouseDown={(event) => {
+                                    event.preventDefault();
+                                    toggleShowOptions();
+                                }}
                             >
-                                <div className="create-board">
-                                    <header className="create-board-header">Add Link here</header>
-                                    <div className="create-board-form">
-                                        <div className="form-label">
+                                <i className="fas fa-chevron-up" />
+                            </button>
+                        ) : null}
+                        {show ?
+                            <main className="modal-wrapper" onClick={outsideClick}>
+                                <div className="modal-section animate-1">
+                                    <header className="modal-header">
+                                        <button onClick={hideModal} className="close-button">
+                                            <i className="fas fa-times" />
+                                        </button>
+                                    </header>
+                                    <div className="create-board">
+                                        <header className="create-board-header">Add Link here</header>
+                                        <div className="create-board-form">
+                                            <div className="form-label">
                                             LINK
+                                            </div>
+                                            <input
+                                                value={link}
+                                                placeholder="Maximum 20 characters"
+                                                onChange={(event) => setLink(event.target.value)}
+                                            />
+                                            <div className="form-error-row" />
                                         </div>
-                                        <input
-                                            value={link}
-                                            placeholder="Maximum 20 characters"
-                                            onChange={(event) => setLink(event.target.value)}
-                                        />
-                                        <div className="form-error-row" />
-                                    </div>
-                                    <footer className="create-board-footer">
-                                        <button
-                                            className="standard-button"
-                                            onClick={onConfirm}
-                                        >
+                                        <footer className="create-board-footer">
+                                            <button
+                                                className="standard-button"
+                                                onClick={onConfirm}
+                                            >
                                             Confirm
-                                        </button>
-                                        <button
-                                            className="standard-button"
-                                            onClick={hideModal}
-                                        >
+                                            </button>
+                                            <button
+                                                className="standard-button"
+                                                onClick={hideModal}
+                                            >
                                             Cancel
-                                        </button>
-                                    </footer>
+                                            </button>
+                                        </footer>
+                                    </div>
                                 </div>
-                            </Modal>
-                            : null}
-                        {showOptions ?
-                            <div className="options-wrapper">
+                            </main> : null}
+                        {showOptions ? (
+                            <div className={`options-wrapper ${optionsVisible ? '' : 'no-display'}`}>
                                 <Options
                                     toggleBlockType={toggleBlockType}
                                     editorState={editorState}
@@ -239,13 +257,15 @@ export const NoteEditor = (props) => {
                                     insertConfig={insertConfig}
                                     toggleInsertType={toggleInsertType}
                                 />
-                            </div> :
-                            null
-                        }
+                            </div>
+                        ) : null}
                     </div>,
-                    <div className="fullscreen-button-wrapper" key="fullscreen-button-wrapper">
-                        <button className="standard-button" onClick={toggleFullScreen}>
-                            <i className="fas fa-expand" />
+                    <div
+                        className={`fullscreen-button-wrapper ${optionsVisible ? '' : 'no-display'}`}
+                        key="fullscreen-button-wrapper"
+                    >
+                        <button className="standard-button" onMouseDown={toggleFullScreen}>
+                            <i className={fullScreenFlag ? 'fas fa-compress' : 'fas fa-expand'} />
                         </button>
                     </div>
                 ]}

--- a/src/pages/notes/components/NoteEditor.js
+++ b/src/pages/notes/components/NoteEditor.js
@@ -197,17 +197,15 @@ export const NoteEditor = (props) => {
                         key={'editor-button-wrapper'}
                         className={`${showOptions ? 'with-options' : ''} editor-button-wrapper`}
                     >
-                        {optionsVisible ? (
-                            <button
-                                className={`standard-button ${optionsVisible ? '' : 'no-display'}`}
-                                onMouseDown={(event) => {
-                                    event.preventDefault();
-                                    toggleShowOptions();
-                                }}
-                            >
-                                <i className="fas fa-chevron-up" />
-                            </button>
-                        ) : null}
+                        <button
+                            className={`standard-button ${optionsVisible ? '' : 'no-display'}`}
+                            onMouseDown={(event) => {
+                                event.preventDefault();
+                                toggleShowOptions();
+                            }}
+                        >
+                            <i className="fas fa-chevron-up" />
+                        </button>
                         {show ?
                             <main className="modal-wrapper" onClick={outsideClick}>
                                 <div className="modal-section animate-1">

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -55,3 +55,7 @@ body {
     }
   }
 }
+
+.no-display {
+  visibility: hidden;
+}

--- a/src/styles/pages/notes.scss
+++ b/src/styles/pages/notes.scss
@@ -285,6 +285,14 @@
         background-color: lighten($color, 5) !important;
       }
     }
+    .modal-wrapper .standard-button {
+      background-color: $green !important;
+      border-radius: 5px;
+      padding: 10px 15px;
+      &:hover {
+        background-color: lighten($color: $green, $amount: 5) !important;
+      }
+    }
     .standard-badge {
       background-color: $color;
     }


### PR DESCRIPTION
### Share modal was invisible in full screen mode

**Root Cause** - in DOM, modal root was not part of note editor, and hence, it was not shown in full screen mode.

**Solution** - Had to introduce a local modal component for this purpose.

### While typing, options were causing distraction in note editor

**Implementation** - Added a timeout and on onChange handler, updating the optionsVisible flag to false and adding a timeout to switch it back to true.